### PR TITLE
feat: Add search functionality for questions with a new router and integrate it into the main app

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -1,11 +1,14 @@
 import express from "express";
 
 import questionsRouter from "./routes/questions.routes.mjs";
+import questionsSearchRouter from "./routes/questions.search.routes.mjs";
 
 const app = express();
 const port = 4000;
 
 app.use(express.json());
+
+app.use("/questions", questionsSearchRouter);
 
 app.use("/questions", questionsRouter);
 

--- a/routes/questions.search.routes.mjs
+++ b/routes/questions.search.routes.mjs
@@ -1,0 +1,46 @@
+import { Router } from "express";
+import connectionPool from "../utils/db.mjs";
+
+const questionsSearchRouter = Router()
+
+questionsSearchRouter.get("/search", async (req, res) => {
+    const { title, category } = req.query;
+  
+    if (!title && !category) {
+      return res.status(400).json({
+        message: "Invalid search parameters.",
+      });
+    }
+  
+    try {
+      let query = `SELECT * FROM questions WHERE 1=1`;
+      const values = [];
+      let index = 1;
+  
+      if (title) {
+        query += ` AND title ILIKE $${index}`;
+        values.push(`%${title}%`);
+        index++;
+      }
+  
+      if (category) {
+        query += ` AND category ILIKE $${index}`;
+        values.push(`%${category}%`);
+        index++;
+      }
+  
+      const results = await connectionPool.query(query, values);
+  
+      return res.status(200).json({
+        data: results.rows,
+      });
+  
+    } catch (err) {
+      return res.status(500).json({
+        message: "Unable to fetch a question.",
+      });
+    }
+  });
+
+  export default questionsSearchRouter;
+  


### PR DESCRIPTION
[Summary]
Adds a questions search endpoint to the Express server, enabling filtering by title and/or category with case-insensitive partial matches.

[Changes]
Routes:
GET /questions/search?title={text}&category={text}
Validation:
Requires at least one of title or category query params
Database:
Parameterized ILIKE search via utils/db.mjs using the shared pg Pool
Errors:
400 for invalid search parameters; 500 for unexpected server/database errors