### PR TITLE
feat: Add answers API with CRUD operations and integrate router into main app

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -2,6 +2,7 @@ import express from "express";
 
 import questionsRouter from "./routes/questions.routes.mjs";
 import questionsSearchRouter from "./routes/questions.search.routes.mjs";
+import answerRouter from "./routes/answer.routes.mjs";
 
 const app = express();
 const port = 4000;
@@ -11,6 +12,8 @@ app.use(express.json());
 app.use("/questions", questionsSearchRouter);
 
 app.use("/questions", questionsRouter);
+
+app.use("/questions", answerRouter);
 
 app.get("/test", (req, res) => {
   return res.json("Server API is working 🚀");

--- a/routes/answer.routes.mjs
+++ b/routes/answer.routes.mjs
@@ -1,0 +1,97 @@
+import { Router } from "express";
+import connectionPool from "../utils/db.mjs";
+
+const answerRouter = Router();
+
+// Create an answer for a question
+answerRouter.post("/:questionId/answers", async (req, res) => {
+  const { questionId } = req.params;
+  const { content } = req.body;
+
+  if (!content) {
+    return res.status(400).json({ message: "Invalid request data." });
+  }
+
+  try {
+    // ตรวจสอบว่าคำถามมีอยู่
+    const questionResult = await connectionPool.query(
+      "SELECT * FROM questions WHERE id = $1",
+      [questionId]
+    );
+
+    if (questionResult.rows.length === 0) {
+      return res.status(404).json({ message: "Question not found." });
+    }
+
+    // เพิ่มคำตอบ
+    await connectionPool.query(
+      "INSERT INTO answers (question_id, content) VALUES ($1, $2)",
+      [questionId, content]
+    );
+
+    return res.status(201).json({ message: "Answer created successfully." });
+
+  } catch (err) {
+    return res.status(500).json({ message: "Unable to create answers." });
+  }
+});
+
+// Get answers for a question
+answerRouter.get("/:questionId/answers", async (req, res) => {
+  const { questionId } = req.params;
+
+  try {
+    // ตรวจสอบว่าคำถามมีอยู่
+    const questionResult = await connectionPool.query(
+      "SELECT * FROM questions WHERE id = $1",
+      [questionId]
+    );
+
+    if (questionResult.rows.length === 0) {
+      return res.status(404).json({ message: "Question not found." });
+    }
+
+    // ดึงคำตอบทั้งหมด
+    const answersResult = await connectionPool.query(
+      "SELECT id, content FROM answers WHERE question_id = $1",
+      [questionId]
+    );
+
+    return res.status(200).json({ data: answersResult.rows });
+
+  } catch (err) {
+    return res.status(500).json({ message: "Unable to fetch answers." });
+  }
+});
+
+// Delete answers for a question
+answerRouter.delete("/:questionId/answers", async (req, res) => {
+  const { questionId } = req.params;
+
+  try {
+    // ตรวจสอบว่าคำถามมีอยู่
+    const questionResult = await connectionPool.query(
+      "SELECT * FROM questions WHERE id = $1",
+      [questionId]
+    );
+
+    if (questionResult.rows.length === 0) {
+      return res.status(404).json({ message: "Question not found." });
+    }
+
+    // ลบคำตอบทั้งหมด
+    await connectionPool.query(
+      "DELETE FROM answers WHERE question_id = $1",
+      [questionId]
+    );
+
+    return res.status(200).json({
+      message: "All answers for the question have been deleted successfully.",
+    });
+
+  } catch (err) {
+    return res.status(500).json({ message: "Unable to delete answers." });
+  }
+});
+
+export default answerRouter;


### PR DESCRIPTION
[Summary]
Adds answer management endpoints to the Express server for creating, listing, and deleting answers associated with a question.

[Changes]
Routes:
POST /questions/:questionId/answers
GET /questions/:questionId/answers
DELETE /questions/:questionId/answers
Validation:
POST requires body { content: string }
All routes validate that the questionId exists
Database:
Uses parameterized queries via utils/db.mjs with the shared pg Pool
Tables: questions (existence check), answers (insert, select, delete by question_id)
Errors:
400 for invalid request body (missing content)
404 if question not found
500 for unexpected server/database errors